### PR TITLE
Introduce byte stream related functionality to entity

### DIFF
--- a/mime-ballerina/byte_stream.bal
+++ b/mime-ballerina/byte_stream.bal
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+// Copyright (c) 2021 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
 //
 // WSO2 Inc. licenses this file to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file except

--- a/mime-ballerina/byte_stream.bal
+++ b/mime-ballerina/byte_stream.bal
@@ -1,0 +1,76 @@
+// Copyright (c) 2020 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/io;
+import ballerina/jballerina.java;
+
+# Represents the type of the record which returned from the byteStream.next() call.
+# 
+# + value - The array of byte
+type StreamEntry record {|
+    byte[] value;
+|};
+
+# `ByteStream` used to initialize a stream of type byte[]. This `ByteStream` refers to the stream that embedded to
+# the I/O byte channels.
+class ByteStream {
+
+    private Entity entity;
+    private int arraySize;
+    private boolean isClosed = false;
+
+    # Initialize a `ByteStream` using a `mime:Entity`.
+    #
+    # + entity - The `mime:Entity` which contains the byte stream
+    # + arraySize - The size of a byte array as an integer
+    public isolated function init(Entity entity, int arraySize) {
+        self.entity = entity;
+        self.arraySize = arraySize;
+    }
+
+    # The next function reads and return the next `byte[]` of the related stream.
+    #
+    # + return - A `byte[]` when the stream is avaliable, null if the stream has reached the end or else an `io:Error`
+    public isolated function next() returns record {|byte[] value;|}|io:Error? {
+        return externGetStreamEntryRecord(self.entity, self.arraySize);
+    }
+
+    # Close the stream. The primary usage of this function is to close the stream without reaching the end.
+    # If the stream reaches the end, the byteStream.next() will automatically close the stream.
+    #
+    # + return - Returns null when the closing was successful or an `io:Error`
+    public isolated function close() returns io:Error? {
+        if (!self.isClosed) {   
+            var closeResult = externCloseInputStream(self.entity);
+            if (closeResult is ()) {
+                self.isClosed = true;
+            }
+            return closeResult;
+        }
+        return ();
+    }
+}
+
+isolated function externGetStreamEntryRecord(Entity entity, int arraySize) returns record {|byte[] value;|}|io:Error? = 
+@java:Method {
+    'class: "org.ballerinalang.mime.nativeimpl.MimeEntityBody",
+    name: "getStreamEntryRecord"
+} external;
+
+isolated function externCloseInputStream(Entity entity) returns io:Error? = @java:Method {
+    'class: "org.ballerinalang.mime.nativeimpl.MimeEntityBody",
+    name: "closeInputByteStream"
+} external;

--- a/mime-ballerina/natives.bal
+++ b/mime-ballerina/natives.bal
@@ -437,8 +437,6 @@ public class Entity {
 
         var value = externGetByteStream(self);
         if (value is ()) {
-            
-        io:println("------------externGetByteStream is (), so create new-------------------");
             MimeByteIterator byteIterator  = new(self, arraySize);
             stream<byte[], io:Error> str  = new stream<byte[], io:Error>(byteIterator);
             return str;

--- a/mime-ballerina/natives.bal
+++ b/mime-ballerina/natives.bal
@@ -262,7 +262,7 @@ public class Entity {
     # mimeEntity.setBody("body string");
     # ```
     #
-    # + entityBody - Entity body can be of the type `string`,`xml`,`json`,`byte[]`, or `Entity[]`.
+    # + entityBody - Entity body can be of the type `string`,`xml`,`json`,`byte[]`,`Entity[]`, or `stream<byte[], io:Error>`
     public isolated function setBody(@untainted string|xml|json|byte[]|Entity[]|stream<byte[], io:Error> entityBody) {
         if (entityBody is string) {
             self.setText(entityBody);
@@ -442,7 +442,7 @@ public class Entity {
     # Gets the body parts as a byte stream from a given entity.
     #
     # + return - Body parts as a byte stream
-    isolated function getBodyPartsAsStream(int arraySize = 8196) returns @tainted stream<byte[], io:Error>|ParserError {
+    public isolated function getBodyPartsAsStream(int arraySize = 8196) returns @tainted stream<byte[], io:Error>|ParserError {
         var value = externGetBodyPartsAsStream(self);
         if (value is ()) {
             ByteStream byteStream  = new(self, arraySize);

--- a/mime-ballerina/natives.bal
+++ b/mime-ballerina/natives.bal
@@ -412,8 +412,8 @@ public class Entity {
 
     # Gets the entity body as a stream of byte[] from a given entity.
     #
-    # + arraySize - An optional size of the byte array. Default size is 8KB
-    # + return - A stream of `io:Block` or else a `mime:ParserError` record will be returned in case of errors
+    # + arraySize - A defaultable paramerter to state the size of the byte array. Default size is 8KB
+    # + return - A byte stream from which the payload can be read or `mime:ParserError` in case of errors
     public isolated function getByteStream(int arraySize = 8196) returns @tainted stream<byte[], io:Error>|ParserError {
         var value = externGetByteStream(self);
         if (value is ()) {
@@ -441,6 +441,7 @@ public class Entity {
 
     # Gets the body parts as a byte stream from a given entity.
     #
+    # + arraySize - A defaultable paramerter to state the size of the byte array. Default size is 8KB
     # + return - Body parts as a byte stream
     public isolated function getBodyPartsAsStream(int arraySize = 8196) returns @tainted stream<byte[], io:Error>|ParserError {
         var value = externGetBodyPartsAsStream(self);

--- a/mime-ballerina/tests/mime_test.bal
+++ b/mime-ballerina/tests/mime_test.bal
@@ -349,6 +349,97 @@ public function testSetFileAsEntityBody() {
 //     }
 // }
 
+//Set byte channel as entity body and get that channel back
+@test:Config {}
+public function testSetByteChannelAndGetByteStream() {
+    string content = "Hello Ballerina!";
+    string fileLocation = checkpanic createTemporaryFile("testFile", ".tmp", content);
+    io:ReadableByteChannel byteChannel = checkpanic io:openReadableFile(fileLocation);
+    Entity entity = new;
+    entity.setByteChannel(byteChannel);
+
+    var str = entity.getByteStream(arraySize = 8);
+
+    if (str is stream<byte[], io:Error>) {
+        record {|byte[] value;|}|io:Error? arr1 = str.next();
+        if (arr1 is record {|byte[] value;|}) {
+            string name = checkpanic strings:fromBytes(arr1.value);
+            test:assertEquals(name, "Hello Ba", msg = "Found unexpected output");
+            record {|byte[] value;|}|io:Error? arr2 = str.next();
+            if (arr2 is record {|byte[] value;|}) {
+                name = checkpanic strings:fromBytes(arr2.value);
+                test:assertEquals(name, "llerina!", msg = "Found unexpected output");
+                record {|byte[] value;|}|io:Error? arr3 = str.next();
+                test:assertTrue(arr3 is (), msg = "Found unexpected output");
+            } else {
+                test:assertFail(msg = "Found unexpected arr2 output type");
+            }
+        } else {
+            test:assertFail(msg = "Found unexpected arr1 output type");
+        }
+    } else {
+       test:assertFail(msg = "Found unexpected str output type" + str.message());
+    }
+}
+
+@test:Config {}
+public function testSetByteChannelAndGetByteStream8k() {
+    string content = "Hello Ballerina!";
+    string fileLocation = checkpanic createTemporaryFile("testFile", ".tmp", content);
+    io:ReadableByteChannel byteChannel = checkpanic io:openReadableFile(fileLocation);
+    Entity entity = new;
+    entity.setByteChannel(byteChannel);
+
+    var str = entity.getByteStream();
+
+    if (str is stream<byte[], io:Error>) {
+        record {|byte[] value;|}|io:Error? arr1 = str.next();
+        if (arr1 is record {|byte[] value;|}) {
+            string name = checkpanic strings:fromBytes(arr1.value);
+            test:assertEquals(name, content, msg = "Found unexpected output");
+            
+            record {|byte[] value;|}|io:Error? arr2 = str.next();
+            test:assertTrue(arr2 is (), msg = "Found unexpected output");
+        } else {
+            test:assertFail(msg = "Found unexpected arr1 output type");
+        }
+    } else {
+       test:assertFail(msg = "Found unexpected str output type" + str.message());
+    }
+}
+
+@test:Config {}
+public function testSetByteChannelAndGetByteStream10() {
+    string content = "Hello Ballerina!";
+    string fileLocation = checkpanic createTemporaryFile("testFile", ".tmp", content);
+    io:ReadableByteChannel byteChannel = checkpanic io:openReadableFile(fileLocation);
+    Entity entity = new;
+    entity.setByteChannel(byteChannel);
+
+    var str = entity.getByteStream(arraySize = 10);
+
+    if (str is stream<byte[], io:Error>) {
+        record {|byte[] value;|}|io:Error? arr1 = str.next();
+        if (arr1 is record {|byte[] value;|}) {
+            string name = checkpanic strings:fromBytes(arr1.value);
+            test:assertEquals(name, "Hello Ball", msg = "Found unexpected output");
+            record {|byte[] value;|}|io:Error? arr2 = str.next();
+            if (arr2 is record {|byte[] value;|}) {
+                name = checkpanic strings:fromBytes(arr2.value);
+                test:assertEquals(name, "erina!", msg = "Found unexpected output");
+                record {|byte[] value;|}|io:Error? arr3 = str.next();
+                test:assertTrue(arr3 is (), msg = "Found unexpected output");
+            } else {
+                test:assertFail(msg = "Found unexpected arr2 output type");
+            }
+        } else {
+            test:assertFail(msg = "Found unexpected arr1 output type");
+        }
+    } else {
+       test:assertFail(msg = "Found unexpected str output type" + str.message());
+    }
+}
+
 //TODO: Enable with new byteStream API
 // //Set entity body as a byte channel get the content back as a string
 // @test:Config {}
@@ -740,7 +831,7 @@ public function getChannelFromMultipartEntity() {
     }
 }
 
-//TODO: Enable with new byteStream API
+// TODO: Enable with new byteStream API
 // //Test whether the string body is retrieved from the cache
 // @test:Config {}
 // public function getAnyStreamAsStringFromCache() {
@@ -756,25 +847,36 @@ public function getChannelFromMultipartEntity() {
 //     test:assertEquals(returnContent, "{'code':'123'}{'code':'123'}", msg = "Found unexpected output");
 // }
 
-//Test whether the string body is retrieved from the cache
-// @test:Config {}
-// public function geStreamTestssssssssssssss() {
-//     // string content = "{'code':'123'}";
-//     // string fileLocation = checkpanic createTemporaryFile("testFile", ".tmp", content);
-//     // io:ReadableByteChannel byteChannel = checkpanic io:openReadableFile(fileLocation);
+@test:Config {}
+public function testseStreamAndGetStream() {
+    byte[][] content = ["ballerina".toBytes(), "language".toBytes()];
+    stream<byte[], io:Error> byteStream = content.toStream();
 
-//     byte[][] content = [[60, 78, 39, 28]];
-//     stream<byte[], io:Error> byteStream = content.toStream();
+    Entity entity = new;
+    entity.setByteStream(byteStream);
+    stream<byte[], io:Error>|ParserError str = entity.getByteStream();
 
-//     Entity entity = new;
-//     entity.setByteStream(byteStream, "application/json");
-//     entity.getByteStream();
-//     string returnContent;
-//     returnContent = checkpanic entity.getText();
-//     //String body should be retrieved from the cache the second time this is called
-//     returnContent = returnContent + checkpanic entity.getText();
-//     test:assertEquals(returnContent, "{'code':'123'}{'code':'123'}", msg = "Found unexpected output");
-// }
+    if (str is stream<byte[], io:Error>) {
+        record {|byte[] value;|}|io:Error? arr1 = str.next();
+        if (arr1 is record {|byte[] value;|}) {
+            string name = checkpanic strings:fromBytes(arr1.value);
+            test:assertEquals(name, "ballerina", msg = "Found unexpected output");
+            record {|byte[] value;|}|io:Error? arr2 = str.next();
+            if (arr2 is record {|byte[] value;|}) {
+                name = checkpanic strings:fromBytes(arr2.value);
+                test:assertEquals(name, "language", msg = "Found unexpected output");
+                record {|byte[] value;|}|io:Error? arr3 = str.next();
+                test:assertTrue(arr3 is (), msg = "Found unexpected output");
+            } else {
+                test:assertFail(msg = "Found unexpected arr2 output type");
+            }
+        } else {
+            test:assertFail(msg = "Found unexpected arr1 output type");
+        }
+    } else {
+       test:assertFail(msg = "Found unexpected str output type" + str.message());
+    }
+}
 
 //TODO: Enable with new byteStream API
 // //Test whether the xml content can be constructed properly once the body has been retrieved as a byte array first

--- a/mime-ballerina/tests/mime_test.bal
+++ b/mime-ballerina/tests/mime_test.bal
@@ -662,7 +662,7 @@ public function testSetContentIdAndGetValueAsHeader() {
 // }
 
 //Test whether the body parts in a multipart entity can be retrieved as a byte channel
-@test:Config {}
+@test:Config {enable:false}
 public function testGetBodyPartsAsChannel() {
     //Create a body part with json content.
     Entity bodyPart1 = new;

--- a/mime-ballerina/tests/mime_test.bal
+++ b/mime-ballerina/tests/mime_test.bal
@@ -1116,7 +1116,7 @@ public function testSeStreamAndGetStream() {
     }
 }
 
-//TODO check Stream.close()
+//TODO check Stream.close(), I think we need to use custom stream here rather the default
 @test:Config {enable:false}
 public function testStreamClose() {
     byte[][] content = ["ballerina".toBytes(), "language".toBytes()];

--- a/mime-ballerina/tests/mime_test.bal
+++ b/mime-ballerina/tests/mime_test.bal
@@ -734,11 +734,16 @@ public function getChannelFromMultipartEntity() {
 //Test whether the string body is retrieved from the cache
 @test:Config {}
 public function getAnyStreamAsStringFromCache() {
-    string content = "{'code':'123'}";
-    string fileLocation = checkpanic createTemporaryFile("testFile", ".tmp", content);
-    io:ReadableByteChannel byteChannel = checkpanic io:openReadableFile(fileLocation);
+    // string content = "{'code':'123'}";
+    // string fileLocation = checkpanic createTemporaryFile("testFile", ".tmp", content);
+    // io:ReadableByteChannel byteChannel = checkpanic io:openReadableFile(fileLocation);
+
+    byte[][] content = [[60, 78, 39, 28]];
+    stream<byte[], io:Error> byteStream = content.toStream();
+
     Entity entity = new;
-    entity.setByteChannel(byteChannel, "application/json");
+    entity.setByteStream(byteStream, "application/json");
+    entity.getByteStream();
     string returnContent;
     returnContent = checkpanic entity.getText();
     //String body should be retrieved from the cache the second time this is called

--- a/mime-native/src/main/java/org/ballerinalang/mime/nativeimpl/MimeEntityBody.java
+++ b/mime-native/src/main/java/org/ballerinalang/mime/nativeimpl/MimeEntityBody.java
@@ -18,6 +18,7 @@
 
 package org.ballerinalang.mime.nativeimpl;
 
+import io.ballerina.runtime.api.Environment;
 import io.ballerina.runtime.api.creators.ValueCreator;
 import io.ballerina.runtime.api.values.BArray;
 import io.ballerina.runtime.api.values.BMap;
@@ -105,11 +106,11 @@ public class MimeEntityBody {
         }
     }
 
-    public static Object getBodyPartsAsChannel(BObject entityObj) {
+    public static Object getBodyPartsAsChannel(Environment env, BObject entityObj) {
         try {
             String contentType = getContentTypeWithParameters(entityObj);
             if (isMultipart(contentType)) {
-                EntityBodyChannel entityBodyChannel = creatEntityBodyChannel(entityObj, contentType);
+                EntityBodyChannel entityBodyChannel = creatEntityBodyChannel(env, entityObj, contentType);
                 BObject byteChannelObj = ValueCreator.createObjectValue(IOUtils.getIOPackage(),
                                                                         READABLE_BYTE_CHANNEL_STRUCT);
                 byteChannelObj.addNativeData(IOConstants.BYTE_CHANNEL_NAME, new EntityWrapper(entityBodyChannel));
@@ -124,11 +125,11 @@ public class MimeEntityBody {
         }
     }
 
-    public static Object getBodyPartsAsStream(BObject entityObj) {
+    public static Object getBodyPartsAsStream(Environment env, BObject entityObj) {
         try {
             String contentType = getContentTypeWithParameters(entityObj);
             if (isMultipart(contentType)) {
-                EntityBodyChannel entityBodyChannel = creatEntityBodyChannel(entityObj, contentType);
+                EntityBodyChannel entityBodyChannel = creatEntityBodyChannel(env, entityObj, contentType);
                 entityObj.addNativeData(ENTITY_BYTE_CHANNEL, new EntityWrapper(entityBodyChannel));
                 return null;
             } else {
@@ -141,11 +142,12 @@ public class MimeEntityBody {
         }
     }
 
-    private static EntityBodyChannel creatEntityBodyChannel(BObject entityObj, String contentType) throws IOException {
+    private static EntityBodyChannel creatEntityBodyChannel(Environment env, BObject entityObj, String contentType)
+            throws IOException {
         String boundaryValue = HeaderUtil.extractBoundaryParameter(contentType);
         String multipartDataBoundary = boundaryValue != null ? boundaryValue : getNewMultipartDelimiter();
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-        MultipartDataSource multipartDataSource = new MultipartDataSource(entityObj, multipartDataBoundary);
+        MultipartDataSource multipartDataSource = new MultipartDataSource(env, entityObj, multipartDataBoundary);
         multipartDataSource.serialize(outputStream);
         EntityBodyChannel entityBodyChannel = new EntityBodyChannel(new ByteArrayInputStream(
                 outputStream.toByteArray()));

--- a/mime-native/src/main/java/org/ballerinalang/mime/nativeimpl/MimeEntityBody.java
+++ b/mime-native/src/main/java/org/ballerinalang/mime/nativeimpl/MimeEntityBody.java
@@ -187,7 +187,6 @@ public class MimeEntityBody {
         if (byteStream != null) {
             return byteStream;
         }
-
         Channel byteChannel = EntityBodyHandler.getByteChannel(entityObj);
         if (byteChannel != null) {
             // Return value implies the absence of previously set byte stream, but to return new iterator to
@@ -218,13 +217,13 @@ public class MimeEntityBody {
             InputStream inputStream = byteChannel.getInputStream();
             try (ByteArrayOutputStream output = new ByteArrayOutputStream()) {
                 byte[] buffer = new byte[arraySizeInt];
-                int len = inputStream.read(buffer, 0, arraySizeInt);
-                if (len == -1) {
+                int readCount = inputStream.read(buffer, 0, arraySizeInt);
+                if (readCount == -1) {
                     EntityBodyHandler.closeByteChannel(byteChannel);
                     entityObj.addNativeData(ENTITY_BYTE_CHANNEL, null);
                     return null;
                 }
-                output.write(buffer, 0, len);
+                output.write(buffer, 0, readCount);
                 bytes = output.toByteArray();
             }
         } catch (IOException ex) {
@@ -242,6 +241,7 @@ public class MimeEntityBody {
         if (byteChannel != null) {
             try {
                 byteChannel.close();
+                entityObj.addNativeData(ENTITY_BYTE_CHANNEL, null);
             } catch (IOException e) {
                 return IOUtils.createError(e);
             }
@@ -283,7 +283,6 @@ public class MimeEntityBody {
         //Clear message data source/byteChannel when the user set a byte stream to entity
         entityObj.addNativeData(ENTITY_BYTE_CHANNEL, null);
         entityObj.addNativeData(MESSAGE_DATA_SOURCE, null);
-
         MimeUtil.setMediaTypeToEntity(entityObj, contentType != null ? contentType.getValue() : OCTET_STREAM);
     }
 

--- a/mime-native/src/main/java/org/ballerinalang/mime/util/MimeConstants.java
+++ b/mime-native/src/main/java/org/ballerinalang/mime/util/MimeConstants.java
@@ -182,6 +182,10 @@ public class MimeConstants {
     public static final String CONTENT_DISPOSITION_FILE_NAME = "filename";
     public static final String CONTENT_DISPOSITION_NAME = "name";
 
+    // Stream entry record
+    public static final String STREAM_ENTRY_RECORD = "StreamEntry";
+    public static final BString FIELD_VALUE = StringUtils.fromString("value");
+
     /**
      * Describes the format of the body part.
      */

--- a/mime-native/src/main/java/org/ballerinalang/mime/util/MimeConstants.java
+++ b/mime-native/src/main/java/org/ballerinalang/mime/util/MimeConstants.java
@@ -185,6 +185,7 @@ public class MimeConstants {
     // Stream entry record
     public static final String STREAM_ENTRY_RECORD = "StreamEntry";
     public static final BString FIELD_VALUE = StringUtils.fromString("value");
+    public static final String BYTE_STREAM_NEXT_FUNC = "next";
 
     /**
      * Describes the format of the body part.

--- a/mime-native/src/main/java/org/ballerinalang/mime/util/MimeConstants.java
+++ b/mime-native/src/main/java/org/ballerinalang/mime/util/MimeConstants.java
@@ -122,6 +122,7 @@ public class MimeConstants {
     public static final String MESSAGE_DATA_SOURCE = "message_datasource";
     public static final String IS_BODY_BYTE_CHANNEL_ALREADY_SET = "is_byte_channel_set";
     public static final String ENTITY_BYTE_CHANNEL = "entity_byte_channel";
+    public static final String ENTITY_BYTE_STREAM = "entity_byte_stream";
     public static final String MULTIPART_ENCODER = "MultipartEncoder";
     public static final String BODY_PARTS = "body_parts";
     public static final String TRANSPORT_MESSAGE = "transport_message";

--- a/mime-native/src/main/java/org/ballerinalang/mime/util/MultipartDataSource.java
+++ b/mime-native/src/main/java/org/ballerinalang/mime/util/MultipartDataSource.java
@@ -18,6 +18,7 @@
 
 package org.ballerinalang.mime.util;
 
+import io.ballerina.runtime.api.Environment;
 import io.ballerina.runtime.api.PredefinedTypes;
 import io.ballerina.runtime.api.creators.TypeCreator;
 import io.ballerina.runtime.api.creators.ValueCreator;
@@ -54,6 +55,7 @@ import static org.ballerinalang.mime.util.MimeConstants.PARAMETER_MAP_FIELD;
 public class MultipartDataSource implements BRefValue {
     private static final Logger log = LoggerFactory.getLogger(MultipartDataSource.class);
 
+    private Environment env;
     private BObject parentEntity;
     private String boundaryString;
     private OutputStream outputStream;
@@ -64,7 +66,8 @@ public class MultipartDataSource implements BRefValue {
     private static final char COLON = ':';
     private static final char SPACE = ' ';
 
-    public MultipartDataSource(BObject entityStruct, String boundaryString) {
+    public MultipartDataSource(Environment env, BObject entityStruct, String boundaryString) {
+        this.env = env;
         this.parentEntity = entityStruct;
         this.boundaryString = boundaryString;
     }
@@ -217,8 +220,7 @@ public class MultipartDataSource implements BRefValue {
         } else {
             Object byteStream = EntityBodyHandler.getByteStream(bodyPart);
             if (byteStream != null) {
-                // TODO stream API: Check if this is needed
-//                EntityBodyHandler.writeByteStreamToOutputStream(bodyPart, outputStream);
+                EntityBodyHandler.writeByteStreamToOutputStream(env, bodyPart, outputStream);
             } else {
                 EntityBodyHandler.writeByteChannelToOutputStream(bodyPart, outputStream);
             }

--- a/mime-native/src/main/java/org/ballerinalang/mime/util/MultipartDataSource.java
+++ b/mime-native/src/main/java/org/ballerinalang/mime/util/MultipartDataSource.java
@@ -215,7 +215,13 @@ public class MultipartDataSource implements BRefValue {
                 ((BRefValue) messageDataSource).serialize(outputStream);
             }
         } else {
-            EntityBodyHandler.writeByteChannelToOutputStream(bodyPart, outputStream);
+            Object byteStream = EntityBodyHandler.getByteStream(bodyPart);
+            if (byteStream != null) {
+                // TODO stream API: Check if this is needed
+//                EntityBodyHandler.writeByteStreamToOutputStream(bodyPart, outputStream);
+            } else {
+                EntityBodyHandler.writeByteChannelToOutputStream(bodyPart, outputStream);
+            }
         }
     }
 


### PR DESCRIPTION
## Purpose
```ballerina
 
   isolated function setByteStream(stream<byte[], io:Error> byteStream,
                                  @untainted string contentType = "application/octet-stream") {
       //...
   }
 
   isolated function getByteStream(int arraySize = 8196) returns 
                                  @tainted stream<byte[], io:Error> |ParserError {
       //...
   }
   
   isolated function getBodyPartsAsStream(int arraySize = 8196) returns 
                                  @tainted stream<byte[], io:Error>|ParserError {
       //...
   }
   
   public isolated function setBody(@untainted string|xml|json|byte[]|
                                   Entity[]|stream<byte[], io:Error> entityBody) {
       //...
   }
```


## Goals
> Alternative for byte channel usage

## Automation tests
 - Unit tests 
   > Added