### PR TITLE
Add Codecov Report Generation

### DIFF
--- a/.github/workflows/build-master.yml
+++ b/.github/workflows/build-master.yml
@@ -26,6 +26,7 @@ jobs:
           packagePAT: ${{ secrets.BALLERINA_BOT_TOKEN }}
         run: |
           ./gradlew publish
+          ./gradlew codeCoverageReport
       - name: Archive Error Log
         uses: actions/upload-artifact@v2
         if: failure()

--- a/.github/workflows/build-master.yml
+++ b/.github/workflows/build-master.yml
@@ -26,7 +26,6 @@ jobs:
           packagePAT: ${{ secrets.BALLERINA_BOT_TOKEN }}
         run: |
           ./gradlew publish
-          ./gradlew codeCoverageReport
       - name: Archive Error Log
         uses: actions/upload-artifact@v2
         if: failure()

--- a/.github/workflows/build-master.yml
+++ b/.github/workflows/build-master.yml
@@ -39,6 +39,8 @@ jobs:
           name: Code Coverage JSON
           path: mime-ballerina/target/report/test_results.json
           if-no-files-found: ignore
+      - name: Generate Codecov Report
+        uses: codecov/codecov-action@v1
       - name: Dispatch Dependent Module Builds
         if: github.event.action != 'stdlib-publish-snapshot'
         run: |

--- a/.github/workflows/build-master.yml
+++ b/.github/workflows/build-master.yml
@@ -39,8 +39,6 @@ jobs:
           name: Code Coverage JSON
           path: mime-ballerina/target/report/test_results.json
           if-no-files-found: ignore
-      - name: Generate CodeCov Report
-        uses: codecov/codecov-action@v1
       - name: Dispatch Dependent Module Builds
         if: github.event.action != 'stdlib-publish-snapshot'
         run: |

--- a/.github/workflows/build-master.yml
+++ b/.github/workflows/build-master.yml
@@ -39,6 +39,8 @@ jobs:
           name: Code Coverage JSON
           path: mime-ballerina/target/report/test_results.json
           if-no-files-found: ignore
+      - name: Generate CodeCov Report
+        uses: codecov/codecov-action@v1
       - name: Dispatch Dependent Module Builds
         if: github.event.action != 'stdlib-publish-snapshot'
         run: |

--- a/.github/workflows/build-master.yml
+++ b/.github/workflows/build-master.yml
@@ -24,8 +24,7 @@ jobs:
         env:
           packageUser: ${{ secrets.BALLERINA_BOT_USERNAME }}
           packagePAT: ${{ secrets.BALLERINA_BOT_TOKEN }}
-        run: |
-          ./gradlew publish
+        run: ./gradlew publish
       - name: Archive Error Log
         uses: actions/upload-artifact@v2
         if: failure()

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -35,7 +35,9 @@ jobs:
             name: Code Coverage JSON
             path: mime-ballerina/target/report/test_results.json
             if-no-files-found: ignore
-
+      - name: Generate Codecov Report
+        uses: codecov/codecov-action@v1
+        
   windows-build:
 
     runs-on: windows-latest

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -21,8 +21,7 @@ jobs:
         env:
           packageUser: ${{ github.actor }}
           packagePAT: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          ./gradlew build
+        run: ./gradlew build
       - name: Archive Error Log
         uses: actions/upload-artifact@v2
         if: failure()
@@ -37,6 +36,7 @@ jobs:
             path: mime-ballerina/target/report/test_results.json
             if-no-files-found: ignore
       - name: Generate Codecov Report
+        if:  github.event_name == 'pull_request'
         uses: codecov/codecov-action@v1
         
   windows-build:

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -21,7 +21,9 @@ jobs:
         env:
           packageUser: ${{ github.actor }}
           packagePAT: ${{ secrets.GITHUB_TOKEN }}
-        run: ./gradlew build
+        run: |
+          ./gradlew build
+          ./gradlew codeCoverageReport
       - name: Archive Error Log
         uses: actions/upload-artifact@v2
         if: failure()

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -23,7 +23,6 @@ jobs:
           packagePAT: ${{ secrets.GITHUB_TOKEN }}
         run: |
           ./gradlew build
-          ./gradlew codeCoverageReport
       - name: Archive Error Log
         uses: actions/upload-artifact@v2
         if: failure()

--- a/build.gradle
+++ b/build.gradle
@@ -110,20 +110,30 @@ task build {
     dependsOn('mime-ballerina:build')
 }
 
-task codeCoverageReport(type: JacocoReport) {
-    executionData fileTree(project.rootDir.absolutePath).include("**/build/coverage-reports/*.exec")
+def classFilesArray = []
 
-    subprojects.each {
-        sourceSets it.sourceSets.main
+task copyClassFilePaths {
+    dependsOn('mime-ballerina:extractBallerinaClassFiles')
+
+    subprojects.forEach { subproject -> 
+        fileTree("${subproject.buildDir}/classes").matching {
+            exclude '**/test/*'
+            exclude '**/module-info.class'
+            include '**/*.class'
+        }.each { file -> classFilesArray.push(file) }
     }
+}
+
+task codeCoverageReport(type: JacocoReport) {
+    dependsOn(copyClassFilePaths)
+    executionData fileTree(project.rootDir.absolutePath).include("**/coverage/*.exec")
+    additionalClassDirs files(classFilesArray)
 
     reports {
         xml.enabled = true
         html.enabled = true
-        csv.enabled = true
         xml.destination = new File("${buildDir}/reports/jacoco/report.xml")
         html.destination = new File("${buildDir}/reports/jacoco/report.html")
-        csv.destination = new File("${buildDir}/reports/jacoco/report.csv")
     }
 
     onlyIf = {

--- a/build.gradle
+++ b/build.gradle
@@ -109,34 +109,3 @@ release {
 task build {
     dependsOn('mime-ballerina:build')
 }
-
-def classFilesArray = []
-
-task copyClassFilePaths {
-    dependsOn('mime-ballerina:extractBallerinaClassFiles')
-
-    subprojects.forEach { subproject -> 
-        fileTree("${subproject.buildDir}/classes").matching {
-            exclude '**/test/*'
-            exclude '**/module-info.class'
-            include '**/*.class'
-        }.each { file -> classFilesArray.push(file) }
-    }
-}
-
-task codeCoverageReport(type: JacocoReport) {
-    dependsOn(copyClassFilePaths)
-    executionData fileTree(project.rootDir.absolutePath).include("**/coverage/*.exec")
-    additionalClassDirs files(classFilesArray)
-
-    reports {
-        xml.enabled = true
-        html.enabled = true
-        xml.destination = new File("${buildDir}/reports/jacoco/report.xml")
-        html.destination = new File("${buildDir}/reports/jacoco/report.html")
-    }
-
-    onlyIf = {
-        true
-    }
-}

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,6 @@
+fixes:
+  - "ballerina/mime/*/::mime-ballerina/"
+
+ignore:
+  - "**/test"
+  

--- a/codecov.yml
+++ b/codecov.yml
@@ -3,4 +3,4 @@ fixes:
 
 ignore:
   - "**/test"
-  
+

--- a/mime-ballerina/build.gradle
+++ b/mime-ballerina/build.gradle
@@ -290,6 +290,20 @@ publishing {
     }
 }
 
+task extractBallerinaClassFiles(type: Copy) {
+    def jars = fileTree(artifactTestableJar).findAll {
+        it.name.endsWith("-testable.jar")
+    }
+
+    jars.forEach { file ->
+        from zipTree(file).matching {
+            exclude '**/tests/*'
+            include '**/*.class'
+        }
+        into "${buildDir}/classes"
+    }
+}
+
 unpackJballerinaTools.dependsOn copyToLib
 unpackStdLibs.dependsOn unpackJballerinaTools
 copyStdlibs.dependsOn unpackStdLibs

--- a/mime-ballerina/build.gradle
+++ b/mime-ballerina/build.gradle
@@ -290,20 +290,6 @@ publishing {
     }
 }
 
-task extractBallerinaClassFiles(type: Copy) {
-    def jars = fileTree(artifactTestableJar).findAll {
-        it.name.endsWith("-testable.jar")
-    }
-
-    jars.forEach { file ->
-        from zipTree(file).matching {
-            exclude '**/tests/*'
-            include '**/*.class'
-        }
-        into "${buildDir}/classes"
-    }
-}
-
 unpackJballerinaTools.dependsOn copyToLib
 unpackStdLibs.dependsOn unpackJballerinaTools
 copyStdlibs.dependsOn unpackStdLibs


### PR DESCRIPTION
## Purpose
- Introducing `Codecov` code coverage report publishing to the `mime` repository

## Goals
- Publishing the testerina generated code coverage xml to `Codecov` triggered via GitHub action of PR.

## Approach
- A new job is inserted to `Pull request` GitHub actions that publishes the XML report to  `Codecov`.
- These jobs trigger on merge to master or pull request and `CodeCov` generates a descriptive code coverage report.
- `Codecov` also adds comments to any PR made based on the code coverage changes between commits

## Test environment
> Ubuntu 20.04

## Related Issues 
- [#28642](https://github.com/ballerina-platform/ballerina-lang/issues/28642)
