### PR TITLE
Make `setFileAsEntityBody` method isolated

### DIFF
--- a/mime-ballerina/natives.bal
+++ b/mime-ballerina/natives.bal
@@ -289,7 +289,8 @@ public class Entity {
     # + filePath - Path of the file
     # + contentType - Content type to be used with the payload. This is an optional parameter.
     #                 The default value is `application/octet-stream`
-    public function setFileAsEntityBody(@untainted string filePath, string contentType = "application/octet-stream") {
+    public isolated function setFileAsEntityBody(@untainted string filePath,
+            string contentType = "application/octet-stream") {
         io:ReadableByteChannel byteChannel = checkpanic io:openReadableFile(filePath);
         self.setByteChannel(byteChannel, contentType = contentType);
     }


### PR DESCRIPTION
## Purpose
> Fixes https://github.com/ballerina-platform/ballerina-standard-library/issues/226