### PR TITLE
Update flag for coverage format

### DIFF
--- a/mime-ballerina/build.gradle
+++ b/mime-ballerina/build.gradle
@@ -59,7 +59,7 @@ ballerina {
     packageOrganization = packageOrg
     module = packageName
     langVersion = ballerinaLangVersion
-    testCoverageParam = "--code-coverage --jacoco-xml --includes=org.ballerinalang.mime.*:ballerina.mime.*"
+    testCoverageParam = "--code-coverage --coverage-format=xml --includes=org.ballerinalang.mime.*:ballerina.mime.*"
 }
 
 configurations {


### PR DESCRIPTION
## Purpose
Update flag for coverage format from '--jacoco-xml' to '--coverage-format=xml'

## Examples

## Checklist
- [ ] Linked to an issue
- [ ] Updated the changelog
- [ ] Added tests