### PR TITLE
Remove checkstyleTest explicit dependency

### DIFF
--- a/mime-native/build.gradle
+++ b/mime-native/build.gradle
@@ -84,8 +84,6 @@ tasks.withType(Checkstyle) {
 
 checkstyleMain.dependsOn(":build-config:checkstyle:downloadMultipleFiles")
 
-checkstyleTest.dependsOn(":build-config:checkstyle:downloadMultipleFiles")
-
 spotbugsMain {
     effort "max"
     reportLevel "low"


### PR DESCRIPTION
This was added to avoid the warning in mime-native:checkstyleTest for gradle 7.1

## Purpose
Related to [`ballerina-platform/module-ballerina-mime/pull/213`](https://github.com/ballerina-platform/module-ballerina-mime/pull/213)

## Examples

## Checklist
- [ ] Linked to an issue
- [ ] Updated the changelog
- [ ] Added tests
