### PR TITLE
Integrate Trivy vulnerability scanner

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -18,6 +18,18 @@ jobs:
         with:
           distribution: 'adopt'
           java-version: 11
+      - name: Build with Gradle
+        env:
+          packageUser: ${{ github.actor }}
+          packagePAT: ${{ secrets.GITHUB_TOKEN }}
+        run: ./gradlew build -x check -x test
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@master
+        with:
+          scan-type: 'fs'
+          scan-ref: '/github/workspace/ballerina/lib'
+          format: 'table'
+          exit-code: '1'
       - name: Set version env variable
         run: echo "VERSION=$((grep -w 'version' | cut -d= -f2) < gradle.properties | rev | cut --complement -d- -f1 | rev)" >> $GITHUB_ENV
       - name: Pre release depenency version update
@@ -34,8 +46,6 @@ jobs:
           sed -i 's/stdlib\(.*\)=\(.*\)-[0-9]\{8\}-[0-9]\{6\}-.*$/stdlib\1=\2/g' gradle.properties
           git add gradle.properties
           git commit -m "Move dependencies to stable version" || echo "No changes to commit"
-      - name: Grant execute permission for gradlew
-        run: chmod +x gradlew
       - name: Publish artifact
         env:
           GITHUB_TOKEN: ${{ secrets.BALLERINA_BOT_TOKEN }}

--- a/.github/workflows/trivy-scan.yml
+++ b/.github/workflows/trivy-scan.yml
@@ -1,15 +1,16 @@
-name: Publish to the Ballerina central
+name: Trivy
 
 on:
-    workflow_dispatch:
+  workflow_dispatch:
+  schedule:
+    - cron:  '0 0 * * *'
 
 jobs:
-  publish-release:
+  ubuntu-build:
+    name: Build on Ubuntu
     runs-on: ubuntu-latest
-    if: github.repository_owner == 'ballerina-platform'
     steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v2
+      - uses: actions/checkout@v2
       - name: Set up JDK 11
         uses: actions/setup-java@v2
         with:
@@ -27,11 +28,3 @@ jobs:
           scan-ref: '/github/workspace/ballerina/lib'
           format: 'table'
           exit-code: '1'
-      - name: Publish artifact
-        env:
-          BALLERINA_CENTRAL_ACCESS_TOKEN: ${{ secrets.BALLERINA_CENTRAL_ACCESS_TOKEN }}
-          packageUser: ${{ secrets.BALLERINA_BOT_USERNAME }}
-          packagePAT: ${{ secrets.BALLERINA_BOT_TOKEN }}
-          GITHUB_TOKEN: ${{ secrets.BALLERINA_BOT_TOKEN }}
-        run: |
-          ./gradlew clean build -PpublishToCentral=true

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@ Ballerina MIME Library
 ===================
 
   [![Build](https://github.com/ballerina-platform/module-ballerina-mime/actions/workflows/build-timestamped-master.yml/badge.svg)](https://github.com/ballerina-platform/module-ballerina-mime/actions/workflows/build-timestamped-master.yml)
+  [![Trivy](https://github.com/ballerina-platform/module-ballerina-mime/actions/workflows/trivy-scan.yml/badge.svg)](https://github.com/ballerina-platform/module-ballerina-mime/actions/workflows/trivy-scan.yml)
   [![GitHub Last Commit](https://img.shields.io/github/last-commit/ballerina-platform/module-ballerina-mime.svg)](https://github.com/ballerina-platform/module-ballerina-mime/commits/master)
-  [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
   [![codecov](https://codecov.io/gh/ballerina-platform/module-ballerina-mime/branch/master/graph/badge.svg)](https://codecov.io/gh/ballerina-platform/module-ballerina-mime)
 
 The `mime` library is one of the standard library packages of the<a target="_blank" href="https://ballerina.io/"> Ballerina</a> language.


### PR DESCRIPTION
## Purpose

This PR integrates the [Trivy](https://github.com/aquasecurity/trivy) vulnerability scanner for repository file system and it will check and generate the report daily or on demand and before the release.

Related to [`Develop security policy for standard libraries #1849`](https://github.com/ballerina-platform/ballerina-standard-library/issues/1849)

## Examples
N/A

## Checklist
- [x] Linked to an issue
- [ ] <s>Updated the changelog</s>
- [ ] <s>Added tests</s>