### PR TITLE
Fix asserting invalid utf-8 encodings using string:fromBytes

### DIFF
--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerina"
 name = "mime"
-version = "2.3.0"
+version = "2.3.1"
 authors = ["Ballerina"]
 keywords = ["mime", "multipart", "entity"]
 repository = "https://github.com/ballerina-platform/module-ballerina-mime"
@@ -10,7 +10,7 @@ license = ["Apache-2.0"]
 distribution = "2201.0.4"
 
 [[platform.java11.dependency]]
-path = "../native/build/libs/mime-native-2.3.0.jar"
+path = "../native/build/libs/mime-native-2.3.1-SNAPSHOT.jar"
 
 
 [[platform.java11.dependency]]

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -75,7 +75,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "mime"
-version = "2.3.0"
+version = "2.3.1"
 dependencies = [
 	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"},
@@ -91,7 +91,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "observe"
-version = "1.0.4"
+version = "1.0.5"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}

--- a/ballerina/tests/mime_test.bal
+++ b/ballerina/tests/mime_test.bal
@@ -865,8 +865,8 @@ public function testBase64DecodeByteArray() {
     string content = "ballerina123";
     byte[] bytes = content.toBytes();
     var res = base64Decode(bytes);
-    if (res is byte[]) {
-        assertByteArray(res, "m�ez��k]�");
+    if res is byte[] {
+        test:assertEquals(res, <byte[]> [109,169,101,122,184,167,107,93,183], msg = "Found unexpected output");
     } else {
         test:assertFail(msg = "Found unexpected output type");
     }
@@ -945,8 +945,8 @@ public function testBase64DecodeBlob() {
     string content = "ballerina123";
     byte[] bytes = content.toBytes();
     var res = base64DecodeBlob(bytes);
-    if (res is byte[]) {
-        assertByteArray(res, "m�ez��k]�");
+    if res is byte[] {
+        test:assertEquals(res, <byte[]> [109,169,101,122,184,167,107,93,183], msg = "Found unexpected output");
     } else {
         test:assertFail(msg = "Found unexpected output type");
     }


### PR DESCRIPTION
## Purpose
$subject validation introduced by https://github.com/ballerina-platform/ballerina-lang/issues/35931

## Examples

## Checklist
- [x] Linked to an issue
- [ ] Updated the changelog
- [ ] Added tests
- [ ] Updated the spec
