### PR TITLE
Add workflow to update specification page in website

### DIFF
--- a/.github/workflows/update_specs.yml
+++ b/.github/workflows/update_specs.yml
@@ -1,0 +1,49 @@
+name: Update Specifications
+
+env:
+    SPEC_FOLDER_PATH: 'docs/spec'
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - master
+      - 2201.1.x
+    paths:
+      - ${{ env.SPEC_FOLDER_PATH }}
+
+jobs:
+  update_specs:
+    name: Update Specifications
+    if: github.repository_owner == 'ballerina-platform'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v2
+
+      - name: Get current date
+        id: date
+        run: echo "::set-output name=date::$(date +'%Y-%m-%d')"
+
+      - name: Get Repo Name
+        id: repo_name
+        run: |
+            MODULE=${{ github.event.repository.name }}
+            echo "::set-output name=short_name::${MODULE##*-}"
+
+      - name: Trigger Workflow
+        run: |
+          curl -X POST \
+          'https://api.github.com/repos/ballerina-platform/ballerina-dev-website/dispatches' \
+          -H 'Accept: application/vnd.github.v3+json' \
+          -H 'Authorization: Bearer ${{ secrets.BALLERINA_BOT_TOKEN }}' \
+          --data "{
+            \"event_type\": \"update-stdlib-specs\",
+            \"client_payload\": {
+              \"module_name\": \"${{ github.event.repository.name }}\",
+              \"short_name\": \"${{ steps.repo_name.outputs.short_name }}\",
+              \"file_dir\": \"${{ github.event.repository.name }}/${{ env.SPEC_FOLDER_PATH }}\",
+              \"release_date\": \"${{ steps.date.outputs.date }}\"
+            }
+          }"


### PR DESCRIPTION
## Purpose
This workflow will be triggered when a change in spec.md happens and will update the specification page in the website.
Related to https://github.com/ballerina-platform/ballerina-standard-library/issues/3154

## Examples

## Checklist
- [x] Linked to an issue
- [ ] Updated the changelog
- [ ] Added tests
- [ ] Updated the spec
