### PR TITLE
[FIX] Invalid runtime API usage when retrieving binary payload from a mime-datasource

### DIFF
--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerina"
 name = "mime"
-version = "2.5.0"
+version = "2.5.1"
 authors = ["Ballerina"]
 keywords = ["mime", "multipart", "entity"]
 repository = "https://github.com/ballerina-platform/module-ballerina-mime"
@@ -12,8 +12,8 @@ distribution = "2201.3.0"
 [[platform.java11.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "mime-native"
-version = "2.5.0"
-path = "../native/build/libs/mime-native-2.5.0.jar"
+version = "2.5.1"
+path = "../native/build/libs/mime-native-2.5.1-SNAPSHOT.jar"
 
 
 [[platform.java11.dependency]]

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -85,7 +85,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "mime"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
 	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"},
@@ -101,7 +101,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "observe"
-version = "1.0.5"
+version = "1.0.6"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}

--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,11 @@ This file contains all the notable changes done to the Ballerina MIME package th
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to 
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+- [Binary payload retrieved from the `http:Request` has different content-length than the original payload](https://github.com/ballerina-platform/ballerina-standard-library/issues/3662)
+
+## Fixed
+
 ## [2.5.0] - 2022-11-29
 
 ### Changed

--- a/changelog.md
+++ b/changelog.md
@@ -5,9 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-- [Binary payload retrieved from the `http:Request` has different content-length than the original payload](https://github.com/ballerina-platform/ballerina-standard-library/issues/3662)
 
 ## Fixed
+- [Binary payload retrieved from the `http:Request` has different content-length than the original payload](https://github.com/ballerina-platform/ballerina-standard-library/issues/3662)
 
 ## [2.5.0] - 2022-11-29
 

--- a/native/src/main/java/io/ballerina/stdlib/mime/nativeimpl/MimeDataSourceBuilder.java
+++ b/native/src/main/java/io/ballerina/stdlib/mime/nativeimpl/MimeDataSourceBuilder.java
@@ -75,10 +75,10 @@ public abstract class MimeDataSourceBuilder {
             String charsetValue = MimeUtil.getContentTypeParamValue(contentTypeValue, CHARSET);
             if (isNotNullAndEmpty(charsetValue)) {
                 return ValueCreator.createArrayValue(
-                        StringUtils.getJsonString(messageDataSource).getBytes(charsetValue));
+                        StringUtils.getStringValue(messageDataSource, null).getBytes(charsetValue));
             }
             return ValueCreator.createArrayValue(
-                    StringUtils.getJsonString(messageDataSource).getBytes(Charset.defaultCharset()));
+                    StringUtils.getStringValue(messageDataSource, null).getBytes(Charset.defaultCharset()));
         }
         return ValueCreator.createArrayValue(new byte[0]);
     }


### PR DESCRIPTION
## Purpose
> $subject

Fixes [#3662](https://github.com/ballerina-platform/ballerina-standard-library/issues/3662)
Related to [#208](https://github.com/wso2-enterprise/internal-support-ballerina/issues/208)

## Examples
N/A

## Checklist
- [X] Linked to an issue
- [X] Updated the changelog
- [ ] ~Added tests~
- [ ] ~Updated the spec~
- [ ] ~Checked native-image compatibility~
