### PR TITLE
Fix buffered writer flush and use SecureRandom for multipart boundary generation

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -8,7 +8,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Fixed
 
+- [Fix buffered writer flush and improve boundary generation randomness in MIME multipart handling](https://github.com/ballerina-platform/ballerina-library/issues/8805)
+
+## [2.12.1] - 2025-11-20
+
+### Fixed
+
 - [Add no content error for runtime parser no content exception](https://github.com/ballerina-platform/ballerina-library/issues/8475)
+
+## [2.12.0] - 2025-03-12
+- This version maintains the latest dependency versions.
 
 ## [2.11.0] - 2025-02-11
 - This version maintains the latest dependency versions.

--- a/native/src/main/java/io/ballerina/stdlib/mime/util/MimeUtil.java
+++ b/native/src/main/java/io/ballerina/stdlib/mime/util/MimeUtil.java
@@ -50,7 +50,7 @@ import java.io.OutputStream;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.Enumeration;
-import java.util.Random;
+import java.security.SecureRandom;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -425,7 +425,7 @@ public class MimeUtil {
      * @return a boundary string
      */
     public static String getNewMultipartDelimiter() {
-        Random random = new Random();
+        SecureRandom random = new SecureRandom();
         return Long.toHexString(random.nextLong());
     }
 

--- a/native/src/main/java/io/ballerina/stdlib/mime/util/MimeUtil.java
+++ b/native/src/main/java/io/ballerina/stdlib/mime/util/MimeUtil.java
@@ -49,8 +49,8 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
-import java.util.Enumeration;
 import java.security.SecureRandom;
+import java.util.Enumeration;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 

--- a/native/src/main/java/io/ballerina/stdlib/mime/util/MultipartDataSource.java
+++ b/native/src/main/java/io/ballerina/stdlib/mime/util/MultipartDataSource.java
@@ -114,6 +114,12 @@ public class MultipartDataSource implements BRefValue {
             writeFinalBoundaryString(writer, parentBoundaryString);
         } catch (IOException e) {
             log.error("Error occurred while writing body parts to outputstream", e.getMessage());
+        } finally {
+            try {
+                writer.flush();
+            } catch (IOException e) {
+                log.error("Error occurred while flushing multipart writer", e.getMessage());
+            }
         }
     }
 

--- a/native/src/main/java/io/ballerina/stdlib/mime/util/MultipartDataSource.java
+++ b/native/src/main/java/io/ballerina/stdlib/mime/util/MultipartDataSource.java
@@ -113,12 +113,12 @@ public class MultipartDataSource implements BRefValue {
             }
             writeFinalBoundaryString(writer, parentBoundaryString);
         } catch (IOException e) {
-            log.error("Error occurred while writing body parts to outputstream", e.getMessage());
+            log.error("Error occurred while writing body parts to outputstream", e);
         } finally {
             try {
                 writer.flush();
             } catch (IOException e) {
-                log.error("Error occurred while flushing multipart writer", e.getMessage());
+                log.error("Error occurred while flushing multipart writer", e);
             }
         }
     }


### PR DESCRIPTION
## Purpose

Resolves https://github.com/ballerina-platform/ballerina-library/issues/8805

## Changes

**`MultipartDataSource.java`** — Added a `finally` block in `serializeBodyPart()` to unconditionally flush the `BufferedWriter`, ensuring buffered data is not lost on the early-return path or when an `IOException` is thrown before `writeFinalBoundaryString()` is reached.

**`MimeUtil.java`** — Replaced `java.util.Random` with `java.security.SecureRandom` in `getNewMultipartDelimiter()` for unpredictable multipart boundary token generation.

**`changelog.md`** — Added missing `[2.12.0]` and `[2.12.1]` entries and updated `[Unreleased]` with this fix.

## Checklist
- [x] Linked to an issue
- [x] Updated the changelog
- [ ] ~Added tests~
- [ ] ~Updated the spec~
- [ ] ~Checked native-image compatibility~

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This pull request addresses issue `#8805` with two focused improvements to MIME multipart handling:

**BufferedWriter Flush Reliability**: Modified `MultipartDataSource.serializeBodyPart()` to unconditionally flush the multipart writer via a finally block. This ensures buffered header data is properly written to the output stream on all execution paths, including early returns when child parts are absent and exception cases during serialization. The writer is not closed since it wraps a caller-owned OutputStream.

**Multipart Boundary Generation**: Updated `MimeUtil.getNewMultipartDelimiter()` to use a more reliable randomness source for generating multipart boundary tokens, replacing the previous approach with enhanced randomization.

**Changelog**: Added missing release entries for versions 2.12.0 and 2.12.1, and documented the fix in the Unreleased section.

The changes maintain backward compatibility with existing method signatures and focus narrowly on improving output reliability and boundary token generation robustness.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ballerina-platform/module-ballerina-mime/pull/571?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->